### PR TITLE
Added/Modified header define checks

### DIFF
--- a/activation.php
+++ b/activation.php
@@ -1,4 +1,7 @@
-<?php if(!defined("AUTO_COMMERCE") || AUTO_COMMERCE!==true)die();
+<?php
+
+if(!defined("ABSPATH"))die();
+
 /**
  * Действия при активации плагина
  */

--- a/an-jwt-auth.php
+++ b/an-jwt-auth.php
@@ -30,6 +30,8 @@
  * GNU General Public License for more details.
  */
 
+if(!defined("ABSPATH"))die();
+
 /**
  * Защита от прямого захода
  */


### PR DESCRIPTION
This removes the check for AUTO_COMMERCE in activation.php so it will work on a system where that plugin is not installed.

Also added checks to other top-level files to be sure they are called from in WordPress and not directly as a security measure. The other files the plugin loads already had a check to be sure the plugin called them.